### PR TITLE
Prevent NullReferenceException in DoubleArgsSatisfy when field is missing from JSON data blob

### DIFF
--- a/JsonLogic.Net.UnitTests/JsonLogicTests.cs
+++ b/JsonLogic.Net.UnitTests/JsonLogicTests.cs
@@ -395,7 +395,7 @@ namespace JsonLogic.Net.UnitTests
         {
             var evaluator = new JsonLogicEvaluator(EvaluateOperators.Default);
 
-            var rule = JObject.Parse(@"{"">"": [{""var"": ""missingField""}, 1000]}");
+            var rule = JObject.Parse(@"{""" + op + @""": [{""var"": ""missingField""}, 1000]}");
 
             var result = evaluator.Apply(rule, Data).IsTruthy();
             

--- a/JsonLogic.Net.UnitTests/JsonLogicTests.cs
+++ b/JsonLogic.Net.UnitTests/JsonLogicTests.cs
@@ -386,6 +386,22 @@ namespace JsonLogic.Net.UnitTests
             Assert.Equal(expected, result);
         }
 
+        [Theory]
+        [InlineData(">", false)]
+        [InlineData(">=", false)]
+        [InlineData("<", true)]
+        [InlineData("<=", true)]
+        public void GreaterThanLessThanWithMissingVar(string op, bool expectedResult)
+        {
+            var evaluator = new JsonLogicEvaluator(EvaluateOperators.Default);
+
+            var rule = JObject.Parse(@"{"">"": [{""var"": ""missingField""}, 1000]}");
+
+            var result = evaluator.Apply(rule, Data).IsTruthy();
+            
+            Assert.Equal(expectedResult, result);
+        }
+
 
         [Fact]
         public void Issue3_FilterBehaviorTest()

--- a/JsonLogic.Net/EvaluateOperators.cs
+++ b/JsonLogic.Net/EvaluateOperators.cs
@@ -309,7 +309,10 @@ namespace JsonLogic.Net
         private Func<IProcessJsonLogic, JToken[], object, object> DoubleArgsSatisfy(Func<double, double, bool> criteria)
         {
             return (p, args, data) => {
-                var values = args.Select(a => a == null ? 0d : Double.Parse(p.Apply(a, data).ToString())).ToArray();
+                var values = args.Select(a => p.Apply(a, data))
+                    .Select(a => a == null ? 0d : double.Parse(a.ToString()))
+                    .ToArray();
+                
                 for (int i = 1; i < values.Length; i++) {
                     if (!criteria(values[i-1], values[i])) return false;
                 }


### PR DESCRIPTION
`{">": [{"var": "missingField"}, 1000]}` will throw a NullReferenceException if "missingField" isn't in the JSON data blob provided to the Apply method.

This pull request adds a default value to the operation, to make sure that if the "var" operation returns null, the argument will get a default value of 0d.

This makes JsonLogic.Net work the same as http://jsonlogic.com/play.html