### PR TITLE
Added new operator "local" that provides scope limiting

### DIFF
--- a/JsonLogic.Net/EvaluateOperators.cs
+++ b/JsonLogic.Net/EvaluateOperators.cs
@@ -259,6 +259,18 @@ namespace JsonLogic.Net
                 double precision = Convert.ToDouble(p.Apply(args[2], data));
                 return Math.Abs(first - second) <= precision;
             });
+
+            // Local processing operator changes scope of evaluations of its 
+            // second argument to result of the first argument
+            // i.e. "local": [ "sourceDataOrLogicAppliedToFullData", "logicToApplyToSourceOnly"]
+            AddOperator("local", (p, args, data) =>
+            {
+                // if blank arguments, return null, since nothing matches conditions
+                if (args.Length < 1) return null;
+                var local = p.Apply(args.First(), data);
+                if (args.Length >= 2) return p.Apply(args[1], local);
+                else return local; // return result of source evaluation
+            });
         }
 
         private object GetValueByName(object data, string namePath)

--- a/additional-operators.md
+++ b/additional-operators.md
@@ -24,3 +24,78 @@ It will return false for this case:
     0.000001 
 ]}
 ```
+
+## local
+
+Complex rules can make it difficul to sequentially operate on results of previous rules. In particular, lack of scope for **var** can be restrictive, since under most conditions (except several array operations) it only operates on the contents of the entire data object. Example could be filtering the array with **filter**, and then accessing a specific field form the first valid match from the resultant object. This can be done with a complex combination of **filter**, **reduce**, **var** and conditions. 
+
+Instead, to simplify processing, a new operator **local** is introduced. 
+**local** accepts two positional arguments:
+* **source** - logic applied to the entire data block as normal that retrieves the data for **logic** argument to operate on. This evaluates as a regular rule and its results are chained into the second argument
+* **logic** - logic applied to the results of the first, **source** argument only. **var** evaluations inside will be scoped to the results of **source** rather than the entire data object
+
+This permits the following logic constructs:
+
+Given data object:
+```json
+{
+    "orchards": [
+        {
+            "name": "Sunny Fruits Orchard", 
+            "apple": 12,
+            "pear": 20
+        },
+        {
+            "name": "Nature's Garden Orchard", 
+            "cherry": 5,
+            "pear": 25
+        }
+    ]
+}
+```
+
+If we want to find out the name of the first orchard that has more than 20 pear trees, we can now do:
+```json
+{
+    "local": [
+        {
+            "filter": [
+                { "var": [ "orchards" ] },
+                { ">": [
+                    { "var": "pear" },
+                    20
+                ]}
+            ]
+        },
+        {
+            "var": "0.name"
+        }
+    ]
+}
+```
+
+Without local, to achieve the same we'd need to use this:
+```json
+{
+    "reduce": [
+        {
+            "filter": [
+                { "var": [ "orchards" ] },
+                { ">": [
+                    { "var": "pear" },
+                    20
+                ]}
+            ]
+        },
+        {
+            "if": [
+                {"var": "accumulator"},
+                {"var": "accumulator"},
+                {"var": "current.name"}
+            ]
+        },
+        null
+    ]
+}
+```
+Logic quickly becomes complicated and nested array accessors (imagine if trees in each orchard were inside their own arrays?) become difficult to follow and interpret. Imagine if we wanted to ask the question about second orchard that satisfies the condition? Easy to do with **local** but starting to require accumulation of state in **reduce**.


### PR DESCRIPTION
I've come across the difficulty of filtering arrays and subsequently selecting specific items from them. This can be done with **reduce**, but for complex evaluations requires state accumulation and makes logic extremely unwieldy. Instead, I have introduced a very simple operator **local** that limits the scope of the second argument evaluation to the results of the first argument. Similar to what **filter** and **map** do already but explicit.

This allows chaining logic evaluations in a very concise manner and makes complex array filtering and accessing logic much more manageable.

Added unit tests and also description with examples to additional_operators.md