### PR TITLE
Minor fixes

### DIFF
--- a/JsonLogic.Net.UnitTests/JsonLogic.Net.UnitTests.csproj
+++ b/JsonLogic.Net.UnitTests/JsonLogic.Net.UnitTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/JsonLogic.Net.UnitTests/JsonLogicTests.cs
+++ b/JsonLogic.Net.UnitTests/JsonLogicTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json;
@@ -260,11 +261,11 @@ namespace JsonLogic.Net.UnitTests
         }
 
         [Theory]
-        [InlineData("{`filter`:[{`var`:`parentArray`},{`and`:[{`===`:[{`var`:`childItem`},`c`]},{`filter`:[{`var`:`childArray`},{`===`:[{`var`:``},5]}]}]}]}", 
-            "{`parentArray`:[{`childArray`:[1,2,3,4,5],`childItem`:`a`},{`childArray`:[4,5],`childItem`:`b`},{`childArray`:[5,6,7,8],`childItem`:`c`}]}", 
+        [InlineData("{`filter`:[{`var`:`parentArray`},{`and`:[{`===`:[{`var`:`childItem`},`c`]},{`filter`:[{`var`:`childArray`},{`===`:[{`var`:``},5]}]}]}]}",
+            "{`parentArray`:[{`childArray`:[1,2,3,4,5],`childItem`:`a`},{`childArray`:[4,5],`childItem`:`b`},{`childArray`:[5,6,7,8],`childItem`:`c`}]}",
             "[{`childArray`:[5,6,7,8],`childItem`:`c`}]")]
-        [InlineData("{`filter`:[{`var`:`parentNonExistentArray`},{`and`:[{`===`:[{`var`:`childItem`},`c`]},{`filter`:[{`var`:`childArray`},{`===`:[{`var`:``},5]}]}]}]}", 
-            "{`parentArray`:[{`childArray`:[1,2,3,4,5],`childItem`:`a`},{`childArray`:[4,5],`childItem`:`b`},{`childArray`:[5,6,7,8],`childItem`:`c`}]}", 
+        [InlineData("{`filter`:[{`var`:`parentNonExistentArray`},{`and`:[{`===`:[{`var`:`childItem`},`c`]},{`filter`:[{`var`:`childArray`},{`===`:[{`var`:``},5]}]}]}]}",
+            "{`parentArray`:[{`childArray`:[1,2,3,4,5],`childItem`:`a`},{`childArray`:[4,5],`childItem`:`b`},{`childArray`:[5,6,7,8],`childItem`:`c`}]}",
             "null")]
         public void NestedFilterVariableAccess(string ruleJson, string dataJson, string expectedJson)
         {
@@ -358,14 +359,14 @@ namespace JsonLogic.Net.UnitTests
 
         [Theory]
         // Null first parameter
-        [InlineData("{`local`:[null, {`var`:[`root.child.2`]}]}", 
-            "{`root`: {`child`:[0,100,200,300]}}", 
+        [InlineData("{`local`:[null, {`var`:[`root.child.2`]}]}",
+            "{`root`: {`child`:[0,100,200,300]}}",
             null)]
-        [InlineData("{`local`:[{`var`:``}, {`var`:[`root.child.2`]}]}", 
-            "{`root`: {`child`:[0,100,200,300]}}", 
+        [InlineData("{`local`:[{`var`:``}, {`var`:[`root.child.2`]}]}",
+            "{`root`: {`child`:[0,100,200,300]}}",
             200.0)]
-        [InlineData("{`local`:[{`var`:`root`}, {`var`:[`root.child.2`]}]}", 
-            "{`root`: {`child`:[0,100,200,300]}}", 
+        [InlineData("{`local`:[{`var`:`root`}, {`var`:[`root.child.2`]}]}",
+            "{`root`: {`child`:[0,100,200,300]}}",
             null)]
         // Null parameters
         [InlineData("{`local`:[]}",
@@ -380,16 +381,16 @@ namespace JsonLogic.Net.UnitTests
             "{`root`: {`child`:[0,100,200,300]}}",
             "{`child`:[0,100,200,300]}")]
         // Simple local filter on complex object
-        [InlineData("{`local`:[{`var`:`root`}, {`var`:[`child.3`]}]}", 
-            "{`root`: {`child`:[0,100,200,300]}}", 
+        [InlineData("{`local`:[{`var`:`root`}, {`var`:[`child.3`]}]}",
+            "{`root`: {`child`:[0,100,200,300]}}",
             300.0)]
         // Filter array and get second element
-        [InlineData("{`local`:[{`filter`:[{`var`:`root.child`},{`>`:[{`var`:``},10]}]},{`var`:[1]}]}", 
-            "{`root`: {`child`:[0,100,200,300]}}", 
+        [InlineData("{`local`:[{`filter`:[{`var`:`root.child`},{`>`:[{`var`:``},10]}]},{`var`:[1]}]}",
+            "{`root`: {`child`:[0,100,200,300]}}",
             200.0)]
         // Filter array of objects and get value of property of first match
         [InlineData("{`local`:[{`filter`:[{`var`:`root.child1`},{`===`:[{`var`:`prop1`},`prop1 value 2`]}]},{`var`:[`0.prop2`]}]}",
-            "{`root`:{`child1`:[{`prop1`:`prop1 value 1`,`prop2`:`prop2 value 1`},{`prop1`:`prop1 value 2`,`prop2`:`prop2 value 2`}],`child2`:42}}", 
+            "{`root`:{`child1`:[{`prop1`:`prop1 value 1`,`prop2`:`prop2 value 1`},{`prop1`:`prop1 value 2`,`prop2`:`prop2 value 2`}],`child2`:42}}",
             "prop2 value 2")]
         // Filter array of objects and try to obtain property when no match found
         [InlineData("{`local`:[{`filter`:[{`var`:`root.child1`},{`===`:[{`var`:`prop1`},`prop1 value 3`]}]},{`var`:[`0.prop2`]}]}",
@@ -443,6 +444,11 @@ namespace JsonLogic.Net.UnitTests
             _output.WriteLine($"{MethodBase.GetCurrentMethod().Name}() Testing {rule} against {data}");
 
             var result = evaluator.Apply(rule, data);
+
+            if (result.GetType().BaseType == typeof(Array))
+            {
+                Assert.Equal((object[])expected, (object[])result);
+            }
             Assert.Equal(expected, result);
         }
 
@@ -458,7 +464,6 @@ namespace JsonLogic.Net.UnitTests
             var rule = JObject.Parse(@"{""" + op + @""": [{""var"": ""missingField""}, 1000]}");
 
             var result = evaluator.Apply(rule, Data).IsTruthy();
-            
             Assert.Equal(expectedResult, result);
         }
 
@@ -514,9 +519,7 @@ namespace JsonLogic.Net.UnitTests
             var result = evaluator.Apply(rules, localData);
 
             // Assert
-            Assert.Equal(1, (result as object[]).Length);
-
-
+            Assert.True(((object[])result).Length == 1);
         }
 
         private object GetDataObject(JToken token)
@@ -535,7 +538,7 @@ namespace JsonLogic.Net.UnitTests
         private object CastPrimitive(object value)
         {
             if (value is int || value is short || value is long || value is double || value is float || value is decimal
-            ) return Convert.ToDouble(value);
+            ) return Convert.ToDouble(value, new NumberFormatInfo());
             return value;
         }
 

--- a/JsonLogic.Net/JsonLogic.Net.csproj
+++ b/JsonLogic.Net/JsonLogic.Net.csproj
@@ -27,7 +27,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.*" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/JsonLogic.Net/JsonLogicEvaluator.cs
+++ b/JsonLogic.Net/JsonLogicEvaluator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json.Linq;
@@ -31,7 +32,7 @@ namespace JsonLogic.Net
 
         private object AdjustType(object value)
         {
-            return value.IsNumeric() ? Convert.ToDouble(value) : value;
+            return value.IsNumeric() ? Convert.ToDouble(value, new NumberFormatInfo()) : value;
         }
     }
 }

--- a/JsonLogic.Net/ObjectExtensions.cs
+++ b/JsonLogic.Net/ObjectExtensions.cs
@@ -1,12 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
-namespace JsonLogic.Net 
+namespace JsonLogic.Net
 {
 
-    public static class ObjectExtensions 
+    public static class ObjectExtensions
     {
         public static bool IsEnumerable(this object d)
         {
@@ -24,11 +25,11 @@ namespace JsonLogic.Net
 
         public static bool EqualTo(this object value, object other)
         {
-            if (value is string || other is string) 
+            if (value is string || other is string)
                 return Convert.ToString(value).Equals(Convert.ToString(other));
-            
+
             if ((value.IsNumeric() || value is bool) && (other.IsNumeric() || other is bool))
-                return Convert.ToDouble(value).Equals(Convert.ToDouble(other));
+                return Convert.ToDouble(value, new NumberFormatInfo()).Equals(Convert.ToDouble(other, new NumberFormatInfo()));
 
             // special handling for nulls to avoid NullReferenceException
             if (value == null)
@@ -41,7 +42,7 @@ namespace JsonLogic.Net
 
 
         /// <summary>
-        /// Equivalent to JavaScript "===" comparer. 
+        /// Equivalent to JavaScript "===" comparer.
         /// </summary>
         /// <param name="value"></param>
         /// <param name="other"></param>
@@ -52,7 +53,7 @@ namespace JsonLogic.Net
         }
 
 
-        public static bool IsNumeric(this object value) 
+        public static bool IsNumeric(this object value)
         {
             return (value is short || value is int || value is long || value is decimal || value is float || value is double);
         }
@@ -61,7 +62,7 @@ namespace JsonLogic.Net
         {
             if (value == null) return false;
             if (value is bool) return (bool) value;
-            if (value.IsNumeric()) return Convert.ToDouble(value) != 0;
+            if (value.IsNumeric()) return Convert.ToDouble(value, new NumberFormatInfo()) != 0;
             if (value.IsEnumerable()) return value.MakeEnumerable().Count() > 0;
             if (value is string) return (value as string).Length > 0;
             return true;


### PR DESCRIPTION
ToDouble "3.14" was on my machine interpreted as 314. Adding a format provider fixed this. Also comparing object[] and string[] failed in one test for which I added a special treatment.