### PR TITLE
Prevent multiple enumeration in GenericArgsSatisfy

### DIFF
--- a/JsonLogic.Net/EvaluateOperators.cs
+++ b/JsonLogic.Net/EvaluateOperators.cs
@@ -320,8 +320,9 @@ namespace JsonLogic.Net
             return (p, args, data) =>
             {
                 var values = args
-                    .Select(a => p.Apply(a, data));
-                    
+                    .Select(a => p.Apply(a, data))
+                    .ToList();
+
                 var isAllText = values
                     .Where(a => a != null)
                     .Select(a => JToken.FromObject(a))


### PR DESCRIPTION
Doing a property like this I was noticing that the line was being printed twice.

```
    public uint Number
    {
        get
        {
            Console.WriteLine("Evaluated Number");
            return _testData.Number;
        }
    }
```

It was being evaluated in the isAllText call and allso in the CheckCriteria call in GenericArgsSatisfy.

Doing a ToList prevents this being evaluated multiple times by preventing multiple enumeration. I plan on having some not as fast logic behind some properties so evaluating these twice would be bad on performance.

This also leads to a ~15% performance increase in my testing.

Before

| Method |     Mean |    Error |   StdDev | Allocated |
|------- |---------:|---------:|---------:|----------:|
|   Test | 946.8 ns | 18.60 ns | 33.54 ns |   1.83 KB |


After

| Method |     Mean |    Error |   StdDev | Allocated |
|------- |---------:|---------:|---------:|----------:|
|   Test | 799.0 ns | 11.86 ns | 11.09 ns |   1.68 KB |

This also passes all the tests in the test project.